### PR TITLE
Answer to issue #104

### DIFF
--- a/public_html/globalResources/searchLinks.js
+++ b/public_html/globalResources/searchLinks.js
@@ -285,10 +285,10 @@ if (goToSearchLink) {
 	  httpRequest.open("POST", "/logSearchLinkData", true);
 	  httpRequest.setRequestHeader("Content-Type", "application/json");
 	  httpRequest.send(JSON.stringify(sidebarSettings));
-	  displayNextRandomQuestion();
 	  let intervalID = {"intervalID": 0};
 	  intervalID.intervalID = setInterval(function(intervalID) {
 		  if (nextQuestion) {
+		    displayNextRandomQuestion();
 			  setTimeout(function() {
 				  toggleAnimation("stop");
 				  setTimeout(function() {


### PR DESCRIPTION
Avoid loading of random question before searchlink has been taken into account. It seems it was simply loaded too soon, I don't see the bug anymore on local.