### PR TITLE
Resolve #104

### DIFF
--- a/public_html/globalResources/searchLinks.js
+++ b/public_html/globalResources/searchLinks.js
@@ -285,6 +285,9 @@ if (goToSearchLink) {
 	  httpRequest.open("POST", "/logSearchLinkData", true);
 	  httpRequest.setRequestHeader("Content-Type", "application/json");
 	  httpRequest.send(JSON.stringify(sidebarSettings));
+	  if (typeof doSomethingOnSidebarSettingsUpdate !== "undefined") {
+		  doSomethingOnSidebarSettingsUpdate();
+	  }
 	  displayNextRandomQuestion();
 	  let intervalID = {"intervalID": 0};
 	  intervalID.intervalID = setInterval(function(intervalID) {


### PR DESCRIPTION
Under some conditions, a first question was loaded before searchlink was taken into account. Ensured loaded question list is cleared after updating sidebar settings from searchlinks so that first question user sees indeed corresponds to the link. This should solve #104 