### PR TITLE
Replace Venser's Journal with new dependencies

### DIFF
--- a/public_html/question-editor/previewData.js
+++ b/public_html/question-editor/previewData.js
@@ -182,7 +182,7 @@ const replaceExpressions = function(string, playerNamesMap, oracle) {
 
 	//Replace rules citations and create tooltips.
 	string = string.replace(/\[(\d{3}(\.\d{1,3}([a-z])?)?)\]/g, function(match, capt1) {
-		return `<a href="https://vensersjournal.com/${capt1}" target="_blank" tooltip="${window.parentData.allRules[capt1] ? window.parentData.allRules[capt1].ruleText.replace(/"/g, "&quot") : "This rule doesn't appear to exist. Please check your citation and try again."}">${capt1}</a>`;
+		return `<a href="https://yawgatog.com/resources/magic-rules/#R${capt1.replace('.','')}" target="_blank" tooltip="${window.parentData.allRules[capt1] ? window.parentData.allRules[capt1].ruleText.replace(/"/g, "&quot") : "This rule doesn't appear to exist. Please check your citation and try again."}">${capt1}</a>`;
 	});
 
 	//Replace card names.

--- a/public_html/recognitions/index.html
+++ b/public_html/recognitions/index.html
@@ -57,7 +57,7 @@
 		<h4 class="header">Kyle Ryc</h4>
 		<p class="content">Kyle is a level 2 judge from Ontario who has been extremely enthusiastic about RulesGuru. Last year at an event, before he was formally a part of the project, he accosted me with inquiries about how best to format a question. He's provided numerous suggestions to improve the website, and was even the inspiration for this very recognition system!</p>
 		<h4 class="header">Andrew Villarrubia</h4>
-		<p class="content">Andrew is a level 2 judge from Louisiana who maintains <a href="http://vensersjournal.com/">Venser's Journal</a>. An incredible standalone resource that also provides RulesGuru with programmatically accessible rules, letting us display those wonderful rules citation tooltips. Andrew has also been active in the <a href="https://chat.magicjudges.org/mtgrules/">rules question IRC channel</a> and has been a point of contact for people with questions or feedback about RulesGuru.</p>
+		<p class="content">Andrew is a level 2 judge from Louisiana who maintains Venser's Journal. An incredible standalone resource that also provides RulesGuru with programmatically accessible rules, letting us display those wonderful rules citation tooltips. Andrew has also been active in the <a href="https://chat.magicjudges.org/mtgrules/">rules question IRC channel</a> and has been a point of contact for people with questions or feedback about RulesGuru.</p>
 
 		<div id="FOUCOverlay"></div>
 		<div id="jsDisabled">

--- a/public_html/rulesguru.js
+++ b/public_html/rulesguru.js
@@ -336,7 +336,7 @@ const replaceExpressions = function(string, playerNamesMap, oracle, citedRules) 
 	});
 
 	string = string.replace(/\[(\d{3}(\.\d{1,3}([a-z])?)?)\]/g, function(match, capt1) {
-		return `<a href="https://vensersjournal.com/${capt1}" target="_blank" tooltip="${citedRules[capt1] ? citedRules[capt1].ruleText.replace(/"/g, "&quot") : "This rule doesn't appear to exist. Please report this issue using the contact form in the upper right."}">${capt1}</a>`;
+		return `<a href="https://yawgatog.com/resources/magic-rules/#R${capt1.replace('.', '')}" target="_blank" tooltip="${citedRules[capt1] ? citedRules[capt1].ruleText.replace(/"/g, "&quot") : "This rule doesn't appear to exist. Please report this issue using the contact form in the upper right."}">${capt1}</a>`;
 	});
 
 	//Replace card names.

--- a/updateDataFiles.js
+++ b/updateDataFiles.js
@@ -437,7 +437,7 @@ if (!fs.existsSync("data_files")) {
 }
 
 let finishedDownloads = 0;
-downloadFile("data_files/rawAllKeywords.json", "https://slack.vensersjournal.com/keywords", function() {
+downloadFile("data_files/rawAllKeywords.json", "https://api.academyruins.com/keywords", function() {
 	try {
 		console.log("rawAllKeywords downloaded");
 		const allKeywords = JSON.parse(fs.readFileSync("data_files/rawAllKeywords.json", "utf8"));
@@ -551,7 +551,7 @@ downloadFile("data_files/rawAllSets.json", "https://mtgjson.com/api/v5/AllPrinti
 	}
 });
 
-downloadFile("data_files/rawAllRules.json", "https://slack.vensersjournal.com/allrules", function() {
+downloadFile("data_files/rawAllRules.json", "https://api.academyruins.com/allrules", function() {
 	console.log("rawAllRules downloaded");
 	try {
 		const rawAllRules = fs.readFileSync("data_files/rawAllRules.json", "utf8");


### PR DESCRIPTION
Venser's Journal has been fully discontinued, including its rules API. A replacement was created at https://api.academyruins.com/ (code at https://github.com/lunakv/academyruins-api). This PR replaces the API calls to Venser's Journal to this new dependency, and sends links to actual rules pages to Yawgatog instead.

As a side-note, I removed the link to VJ in the recognitions page (as it'll be invalid on June 1st), but otherwise left the text unchanged, leaving it to y'all to decide if you want to do anything with it.