### PR TITLE
Add a debounce timer for the question list toggle function

### DIFF
--- a/public_html/rulesguru.js
+++ b/public_html/rulesguru.js
@@ -549,7 +549,11 @@ bindButtonAction(document.getElementById("nextQuestion"), displayNextRandomQuest
 
 //Questions list
 let questionsListOpen = false;
+let questionListToggleDebounceActive = false;
 const toggleQuestionsList = function() {
+	//because on mobile a touch can trigger this twice, we'll need to debounce this function
+	if (questionListToggleDebounceActive) return;
+	questionListToggleDebounceActive = true;
 	if (questionsListOpen) {
 		document.getElementById("questionsListArea").style.transform = "translate(-9.3rem)";
 		document.getElementById("moveForQuestionsList").style.width = "";
@@ -561,6 +565,7 @@ const toggleQuestionsList = function() {
 		document.getElementById("sidebarShowQuestionsList").innerHTML = "Hide All";
 		questionsListOpen = true;
 	}
+	setTimeout(() => questionListToggleDebounceActive = false, 10); //I have no idea how long is appropriate but this seems to work
 }
 bindButtonAction(document.getElementById("sidebarShowQuestionsList"), toggleQuestionsList);
 


### PR DESCRIPTION
Closes #156.

The issue appears to be just the fact that touches on mobile frequently result in both `mouseup` and `touchend` events, but the button acts as a toggle, so two events has the same effect as none.

I solved it by adding a debounce timer (with a fairly arbitrary value of 10 milliseconds).  This does mean that if you click/touch rapidly, not every click/touch will register, but I couldn't find a timing that was both long enough to consistently prevent the original issue without raising this new one.  I think this is a rather less serious issue to introduce, so I think it's fine.

I'm not sure this is really the best solution to this problem, because you'll notice it's specific to this function.  Might be better to have some sort of more general debounce functionality related to the `mouseup`/`touchend` scenario, but I couldn't figure out how to do that.  (The other buttons are of course bouncing in this manner as well, it's just less obvious!  E.g., if next question bounces, does that really matter?)

Alternatively, for this particular case, this could perhaps better be solved by A. not having the function be a toggle, but rather set things to a specific value, and B. replacing the show/hide button with two *different* buttons, of which only one is visible at a time; then the bouncing simply wouldn't matter.  I think this way is actually probably better, and I tried it, but for some reason the resulting layout was wrong.  (Can show you if you want, maybe you'll have some idea why; I'm stumped.)

Regardless, while this might not be the best solution, it sure is simple.