### PR TITLE
Require spaces in split card check to allow SP//dr

### DIFF
--- a/custom_modules/updateDataFiles.js
+++ b/custom_modules/updateDataFiles.js
@@ -836,7 +836,7 @@ const allCardsProbablyValid = function(allCards) {//MTGJSON has a tendency to br
 		}
 
 		//Check for any multi-part cards in the original files that slipped through.
-		if (allCards[i].name.includes("//") && !allCards[i].layout.includes("split")) {
+		if (allCards[i].name.includes(" // ") && !allCards[i].layout.includes("split")) {
 			return `${allCards[i].name} exists. It should not.`;
 		}
 


### PR DESCRIPTION
Right now, if you run the update data files script, it will complain at you about "SP//dr, Piloted by Peni". So I altered the check to avoid this. I figure there's two ways to do this -- add spaces (a generic solution), or specifically list that card as an exception.  I went with the former, but either should work.