### PR TITLE
Handle the case where alternate Furious doesn't exist

### DIFF
--- a/custom_modules/updateDataFiles.js
+++ b/custom_modules/updateDataFiles.js
@@ -101,6 +101,8 @@ const updateAllCards = function(verbose = false) {
 			//sometimes Scryfall only returns the alternate Fast and not the alternate Furious??
 			alt__card_b["name"] = "Fasto // Furiouso"
 			alt__card_b["faceName"] = "Furiouso"
+		} else {
+			alt__card_a.layout = "normal" //HACK!! but what else to do here?
 		}
 		notFlatAllCards["Fast // Furious"]   = [norm_card_a, norm_card_b]
 		notFlatAllCards["Fasto // Furiouso"] = alt__card_b ? [alt__card_a, alt__card_b] : [alt__card_a];

--- a/custom_modules/updateDataFiles.js
+++ b/custom_modules/updateDataFiles.js
@@ -96,11 +96,14 @@ const updateAllCards = function(verbose = false) {
 		let alt__card_a = cards.find((card) => (card["faceName"] == "Fast"    && card["text"].startsWith("Target creature")))
 		let alt__card_b = cards.find((card) => (card["faceName"] == "Furious" && card["text"].startsWith("Target creature")))
 		alt__card_a["name"] = "Fasto // Furiouso"
-		alt__card_b["name"] = "Fasto // Furiouso"
 		alt__card_a["faceName"] = "Fasto"
-		alt__card_b["faceName"] = "Furiouso"
+		if (alt__card_b) {
+			//sometimes Scryfall only returns the alternate Fast and not the alternate Furious??
+			alt__card_b["name"] = "Fasto // Furiouso"
+			alt__card_b["faceName"] = "Furiouso"
+		}
 		notFlatAllCards["Fast // Furious"]   = [norm_card_a, norm_card_b]
-		notFlatAllCards["Fasto // Furiouso"] = [alt__card_a, alt__card_b]
+		notFlatAllCards["Fasto // Furiouso"] = alt__card_b ? [alt__card_a, alt__card_b] : [alt__card_a];
 	}
 
 	// Add in dungeons manually


### PR DESCRIPTION
The update script is crashing because for some reason Scryfall's data apparently now only includes the alternate Fast and not the alternate Furious.  I added some conditionals to "handle" this situation (the handling doesn't really make sense, but then, it's a nonsensical situation we've been asked to deal with).  At least it doesn't crash...

Edit: Oops, yes it does, dunno why I thought it didn't.  Sorry about that, fixing.

Edit: Seems like the reason for the problem is that there's some problem with the data regarding Insult//Injury??  What do we do, just wait for them to fix that...?