### PR TITLE
Add new keyword parser (but don't yet fully hook it up)

### DIFF
--- a/custom_modules/keywordDetails.json
+++ b/custom_modules/keywordDetails.json
@@ -1,0 +1,796 @@
+[
+	{
+		"keyword": "deathtouch"
+	},
+	{
+		"keyword": "defender"
+	},
+	{
+		"keyword": "double strike"
+	},
+	{
+		"keyword": "enchant",
+		"argument": "required"
+	},
+	{
+		"keyword": "equip",
+		"argument": "optional",
+		"cost": "required",
+		"variants": [{
+			"keyword": "equip planeswalker",
+			"cost": "required"
+		}]
+	},
+	{
+		"keyword": "first strike"
+	},
+	{
+		"keyword": "flash"
+	},
+	{
+		"keyword": "flying"
+	},
+	{
+		"keyword": "haste"
+	},
+	{
+		"keyword": "hexproof",
+		"variants": [{
+			"keyword": "hexproof from",
+			"argument": "required",
+			"fromMultiple": "from"
+		}]
+	},
+	{
+		"keyword": "indestructible"
+	},
+	{
+		"keyword": "intimidate"
+	},
+	{
+		"keyword": "landwalk",
+		"argument": "required",
+		"argumentType": "prefix",
+		"keywordText": "walk"
+	},
+	{
+		"keyword": "lifelink"
+	},
+	{
+		"keyword": "protection",
+		"keywordText": "protection from",
+		"argument": "required",
+		"fromMultiple": "from"
+	},
+	{
+		"keyword": "reach"
+	},
+	{
+		"keyword": "shroud"
+	},
+	{
+		"keyword": "trample",
+		"variants": [{
+			"keyword": "trample over planeswalkers"
+		}]
+	},
+	{
+		"keyword": "vigilance"
+	},
+	{
+		"keyword": "ward",
+		"cost": "required"
+	},
+	{
+		"keyword": "banding",
+		"variants": [{
+			"keyword": "bands with other",
+			"argument": "required"
+		}]
+	},
+	{
+		"keyword": "rampage",
+		"argument": "required",
+		"argumentType": "numeric"
+	},
+	{
+		"keyword": "cumulative upkeep",
+		"cost": "required"
+	},
+	{
+		"keyword": "flanking"
+	},
+	{
+		"keyword": "phasing"
+	},
+	{
+		"keyword": "buyback",
+		"cost": "required"
+	},
+	{
+		"keyword": "shadow"
+	},
+	{
+		"keyword": "cycling",
+		"cost": "required",
+		"variants": [{
+			"keyword": "typecycling",
+			"keywordText": "cycling",
+			"argument": "required",
+			"argumentType": "prefix",
+			"cost": "required"
+		}]
+	},
+	{
+		"keyword": "echo",
+		"cost": "required"
+	},
+	{
+		"keyword": "horsemanship"
+	},
+	{
+		"keyword": "fading",
+		"argument": "required",
+		"argumentType": "numeric"
+	},
+	{
+		"keyword": "kicker",
+		"cost": "required",
+		"costMultiple": true,
+		"variants": [
+			{
+				"keyword": "multikicker",
+				"cost": "required"
+			},
+			{
+				"keyword": "sticker kicker",
+				"cost": "required"
+			}
+		]
+	},
+	{
+		"keyword": "flashback",
+		"cost": "required"
+	},
+	{
+		"keyword": "madness",
+		"cost": "required"
+	},
+	{
+		"keyword": "fear"
+	},
+	{
+		"keyword": "morph",
+		"cost": "required",
+		"variants": [{
+			"keyword": "megamorph",
+			"cost": "required"
+		}]
+	},
+	{
+		"keyword": "amplify",
+		"argument": "required",
+		"argumentType": "numeric"
+	},
+	{
+		"keyword": "provoke"
+	},
+	{
+		"keyword": "storm"
+	},
+	{
+		"keyword": "affinity",
+		"keywordText": "affinity for",
+		"argument": "required"
+	},
+	{
+		"keyword": "entwine",
+		"cost": "required"
+	},
+	{
+		"keyword": "modular",
+		"argument": "required",
+		"argumentType": "numeric"
+	},
+	{
+		"keyword": "sunburst",
+		"actsAsNumber": true
+	},
+	{
+		"keyword": "bushido",
+		"argument": "required",
+		"argumentType": "numeric"
+	},
+	{
+		"keyword": "soulshift",
+		"argument": "required",
+		"argumentType": "numeric"
+	},
+	{
+		"keyword": "splice",
+		"keywordText": "splice onto",
+		"argument": "required",
+		"cost": "required"
+	},
+	{
+		"keyword": "offering",
+		"argument": "required",
+		"argumentType": "before"
+	},
+	{
+		"keyword": "ninjutsu",
+		"cost": "required",
+		"variants": [{
+			"keyword": "commander ninjutsu",
+			"cost": "required"
+		}]
+	},
+	{
+		"keyword": "epic"
+	},
+	{
+		"keyword": "convoke"
+	},
+	{
+		"keyword": "dredge",
+		"argument": "required",
+		"argumentType": "numeric"
+	},
+	{
+		"keyword": "transmute",
+		"cost": "required"
+	},
+	{
+		"keyword": "bloodthirst",
+		"argument": "required",
+		"argumentType": "numeric",
+		"variants": [{
+			"keyword": "bloodthirst X"
+		}]
+	},
+	{
+		"keyword": "haunt"
+	},
+	{
+		"keyword": "replicate",
+		"cost": "required"
+	},
+	{
+		"keyword": "forecast",
+		"argument": "required",
+		"argumentType": "dashed"
+	},
+	{
+		"keyword": "graft",
+		"argument": "required",
+		"argumentType": "numeric"
+	},
+	{
+		"keyword": "recover",
+		"cost": "required"
+	},
+	{
+		"keyword": "ripple",
+		"argument": "required",
+		"argumentType": "numeric"
+	},
+	{
+		"keyword": "split second"
+	},
+	{
+		"keyword": "suspend",
+		"argument": "required",
+		"argumentType": "numeric",
+		"cost": "required"
+	},
+	{
+		"keyword": "vanishing",
+		"argument": "optional",
+		"argumentType": "numeric"
+	},
+	{
+		"keyword": "absorb",
+		"argument": "required",
+		"argumentType": "numeric"
+	},
+	{
+		"keyword": "aura swap",
+		"cost": "required"
+	},
+	{
+		"keyword": "delve"
+	},
+	{
+		"keyword": "fortify",
+		"cost": "required"
+	},
+	{
+		"keyword": "frenzy",
+		"argument": "required",
+		"argumentType": "numeric"
+	},
+	{
+		"keyword": "gravestorm"
+	},
+	{
+		"keyword": "poisonous",
+		"argument": "required",
+		"argumentType": "numeric"
+	},
+	{
+		"keyword": "transfigure",
+		"cost": "required"
+	},
+	{
+		"keyword": "champion",
+		"keywordText": ["champion a", "champion an"],
+		"argument": "required"
+	},
+	{
+		"keyword": "changeling"
+	},
+	{
+		"keyword": "evoke",
+		"cost": "required"
+	},
+	{
+		"keyword": "hideaway",
+		"argument": "required",
+		"argumentType": "numeric"
+	},
+	{
+		"keyword": "prowl",
+		"cost": "required"
+	},
+	{
+		"keyword": "reinforce",
+		"argument": "required",
+		"argumentType": "numeric",
+		"cost": "required"
+	},
+	{
+		"keyword": "conspire"
+	},
+	{
+		"keyword": "persist"
+	},
+	{
+		"keyword": "wither"
+	},
+	{
+		"keyword": "retrace"
+	},
+	{
+		"keyword": "devour",
+		"variant": "optional",
+		"argument": "required",
+		"argumentType": "numeric"
+	},
+	{
+		"keyword": "exalted"
+	},
+	{
+		"keyword": "unearth",
+		"cost": "required"
+	},
+	{
+		"keyword": "cascade"
+	},
+	{
+		"keyword": "annihilator",
+		"argument": "required",
+		"argumentType": "numeric"
+	},
+	{
+		"keyword": "level up",
+		"cost": "required"
+	},
+	{
+		"keyword": "rebound"
+	},
+	{
+		"keyword": "umbra armor"
+	},
+	{
+		"keyword": "infect"
+	},
+	{
+		"keyword": "battle cry"
+	},
+	{
+		"keyword": "living weapon"
+	},
+	{
+		"keyword": "undying"
+	},
+	{
+		"keyword": "miracle",
+		"cost": "required"
+	},
+	{
+		"keyword": "soulbond"
+	},
+	{
+		"keyword": "overload",
+		"cost": "required"
+	},
+	{
+		"keyword": "scavenge",
+		"cost": "required"
+	},
+	{
+		"keyword": "unleash"
+	},
+	{
+		"keyword": "cipher"
+	},
+	{
+		"keyword": "evolve"
+	},
+	{
+		"keyword": "extort"
+	},
+	{
+		"keyword": "fuse"
+	},
+	{
+		"keyword": "bestow",
+		"cost": "required"
+	},
+	{
+		"keyword": "tribute",
+		"argument": "required",
+		"argumentType": "numeric"
+	},
+	{
+		"keyword": "dethrone"
+	},
+	{
+		"keyword": "hidden agenda",
+		"variants": [{
+			"keyword": "double agenda"
+		}]
+	},
+	{
+		"keyword": "outlast",
+		"cost": "required"
+	},
+	{
+		"keyword": "prowess"
+	},
+	{
+		"keyword": "dash",
+		"cost": "required"
+	},
+	{
+		"keyword": "exploit"
+	},
+	{
+		"keyword": "menace"
+	},
+	{
+		"keyword": "renown",
+		"argument": "required",
+		"argumentType": "numeric"
+	},
+	{
+		"keyword": "awaken",
+		"argument": "required",
+		"argumentType": "numeric",
+		"cost": "required"
+	},
+	{
+		"keyword": "devoid"
+	},
+	{
+		"keyword": "ingest"
+	},
+	{
+		"keyword": "myriad"
+	},
+	{
+		"keyword": "surge",
+		"cost": "required"
+	},
+	{
+		"keyword": "skulk"
+	},
+	{
+		"keyword": "emerge",
+		"cost": "required",
+		"variants": [{
+			"keyword": "emerge from",
+			"argument": "required",
+			"cost": "required"
+		}]
+	},
+	{
+		"keyword": "escalate",
+		"cost": "required"
+	},
+	{
+		"keyword": "melee"
+	},
+	{
+		"keyword": "crew",
+		"argument": "required",
+		"argumentType": "numeric"
+	},
+	{
+		"keyword": "fabricate",
+		"argument": "required",
+		"argumentType": "numeric"
+	},
+	{
+		"keyword": "partner",
+		"variant": "optional",
+		"variantType": "dashed",
+		"variants": [
+			{
+				"keyword": "partner with",
+				"argument": "required"
+			},
+			{
+				"keyword": "choose a Background"
+			},
+			{
+				"keyword": "Doctor's companion"
+			}
+		]
+	},
+	{
+		"keyword": "undaunted"
+	},
+	{
+		"keyword": "improvise"
+	},
+	{
+		"keyword": "aftermath"
+	},
+	{
+		"keyword": "embalm",
+		"cost": "required"
+	},
+	{
+		"keyword": "eternalize",
+		"cost": "required"
+	},
+	{
+		"keyword": "afflict",
+		"argument": "required",
+		"argumentType": "numeric"
+	},
+	{
+		"keyword": "ascend"
+	},
+	{
+		"keyword": "assist"
+	},
+	{
+		"keyword": "jump-start"
+	},
+	{
+		"keyword": "mentor"
+	},
+	{
+		"keyword": "afterlife",
+		"argument": "required",
+		"argumentType": "numeric"
+	},
+	{
+		"keyword": "riot"
+	},
+	{
+		"keyword": "spectacle",
+		"cost": "required"
+	},
+	{
+		"keyword": "escape",
+		"cost": "required"
+	},
+	{
+		"keyword": "companion",
+		"argument": "required",
+		"argumentType": "dashed"
+	},
+	{
+		"keyword": "mutate",
+		"cost": "required"
+	},
+	{
+		"keyword": "encore",
+		"cost": "required"
+	},
+	{
+		"keyword": "boast",
+		"argument": "required",
+		"argumentType": "dashed"
+	},
+	{
+		"keyword": "foretell",
+		"cost": "required"
+	},
+	{
+		"keyword": "demonstrate"
+	},
+	{
+		"keyword": "daybound"
+	},
+	{
+		"keyword": "nightbound"
+	},
+	{
+		"keyword": "disturb",
+		"cost": "required"
+	},
+	{
+		"keyword": "decayed"
+	},
+	{
+		"keyword": "cleave",
+		"cost": "required"
+	},
+	{
+		"keyword": "training"
+	},
+	{
+		"keyword": "compleated"
+	},
+	{
+		"keyword": "reconfigure",
+		"cost": "required"
+	},
+	{
+		"keyword": "blitz",
+		"cost": "required"
+	},
+	{
+		"keyword": "casualty",
+		"argument": "required",
+		"argumentType": "numeric"
+	},
+	{
+		"keyword": "enlist"
+	},
+	{
+		"keyword": "read ahead"
+	},
+	{
+		"keyword": "ravenous"
+	},
+	{
+		"keyword": "squad",
+		"cost": "required"
+	},
+	{
+		"keyword": "space sculptor"
+	},
+	{
+		"keyword": "prototype",
+		"cost": "required",
+		"argument": "required",
+		"reverseOrder": true
+	},
+	{
+		"keyword": "living metal"
+	},
+	{
+		"keyword": "more than meets the eye",
+		"cost": "required"
+	},
+	{
+		"keyword": "for mirrodin!"
+	},
+	{
+		"keyword": "toxic",
+		"argument": "required",
+		"argumentType": "numeric"
+	},
+	{
+		"keyword": "backup",
+		"argument": "required",
+		"argumentType": "numeric"
+	},
+	{
+		"keyword": "bargain"
+	},
+	{
+		"keyword": "craft",
+		"keywordText": "craft with",
+		"argument": "required",
+		"cost": "required"
+	},
+	{
+		"keyword": "disguise",
+		"cost": "required"
+	},
+	{
+		"keyword": "solved",
+		"argument": "required",
+		"argumentType": "dashed"
+	},
+	{
+		"keyword": "plot",
+		"cost": "required"
+	},
+	{
+		"keyword": "saddle",
+		"argument": "required",
+		"argumentType": "numeric"
+	},
+	{
+		"keyword": "spree"
+	},
+	{
+		"keyword": "freerunning",
+		"cost": "required"
+	},
+	{
+		"keyword": "gift",
+		"keywordText": ["gift a", "gift an"],
+		"variant": "required"
+	},
+	{
+		"keyword": "offspring",
+		"cost": "required"
+	},
+	{
+		"keyword": "impending",
+		"argument": "required",
+		"argumentType": "numeric",
+		"cost": "required"
+	},
+	{
+		"keyword": "exhaust",
+		"argument": "required",
+		"argumentType": "dashed"
+	},
+	{
+		"keyword": "max speed",
+		"argument": "required",
+		"argumentType": "dashed"
+	},
+	{
+		"keyword": "start your engines!"
+	},
+	{
+		"keyword": "harmonize",
+		"cost": "required"
+	},
+	{
+		"keyword": "mobilize",
+		"argument": "required",
+		"argumentType": "numeric"
+	},
+	{
+		"keyword": "job select"
+	},
+	{
+		"keyword": "tiered"
+	},
+	{
+		"keyword": "station"
+	},
+	{
+		"keyword": "warp",
+		"cost": "required"
+	},
+	{
+		"keyword": "∞",
+		"argument": "required",
+		"argumentType": "dashed"
+	},
+	{
+		"keyword": "mayhem",
+		"cost": "optional"
+	},
+	{
+		"keyword": "web-slinging",
+		"cost": "required"
+	},
+	{
+		"keyword": "firebending",
+		"argument": "required",
+		"argumentType": "numeric"
+	}
+]

--- a/custom_modules/keywordDetails.json
+++ b/custom_modules/keywordDetails.json
@@ -10,7 +10,8 @@
 	},
 	{
 		"keyword": "enchant",
-		"argument": "required"
+		"argument": "required",
+		"allowsCommas": true
 	},
 	{
 		"keyword": "equip",
@@ -38,7 +39,8 @@
 		"variants": [{
 			"keyword": "hexproof from",
 			"argument": "required",
-			"fromMultiple": "from"
+			"fromMultiple": "from",
+			"allowsCommas": true
 		}]
 	},
 	{
@@ -60,7 +62,8 @@
 		"keyword": "protection",
 		"keywordText": "protection from",
 		"argument": "required",
-		"fromMultiple": "from"
+		"fromMultiple": "from",
+		"allowsCommas": true
 	},
 	{
 		"keyword": "reach"
@@ -528,7 +531,8 @@
 		"variants": [
 			{
 				"keyword": "partner with",
-				"argument": "required"
+				"argument": "required",
+				"allowsCommas": true
 			},
 			{
 				"keyword": "choose a Background"
@@ -698,7 +702,8 @@
 		"keyword": "craft",
 		"keywordText": "craft with",
 		"argument": "required",
-		"cost": "required"
+		"cost": "required",
+		"allowsCommas": true
 	},
 	{
 		"keyword": "disguise",

--- a/custom_modules/keywordParser.js
+++ b/custom_modules/keywordParser.js
@@ -1,17 +1,21 @@
 //NOTE: officially, "protection from everything" is a variant, but I chose to leave it as argument
 
 function parseRulesTextForKeywordAbilities(rulesText, keywords) {
-	const numberKeywords = keywords.filter(keyword => keyword.actsAsNumber).map(keyword => keyword.keyword); //I'm assuming no variants do this
+	const numberKeywords = keywords.filter(
+		keyword => keyword.actsAsNumber
+	).map(
+		keyword => keyword.keyword.toLowerCase()
+	); //I'm assuming no variants do this
 	let keywordsFound = [];
-	const lines = rulesText.split(/\r?\n/);
+	const lines = rulesText.split(/(\r?\n|;)/); //we consider semicolons to act like line breaks
 	lines: for (const line of lines) {
 		let keywordsFoundOnLine = [];
-		const segments = line.split(/[,;]\s*/);
+		const segments = line.split(",");
 		for (const segment of segments) {
 			//we're going to check each segment to see if it's a keyword.
 			//if it's *not* a keyword, we discard the entire line, since
 			//no line ever contains both keyword and non-keyword segments.
-			const { parse, wholeLine } = parseSegment(segment, line, keywords, numberKeywords);
+			const { parse, wholeLine } = parseSegment(segment.trim(), line.trim(), keywords, numberKeywords);
 			const parses = handleArrays(parse);
 			if (parse !== null) {
 				if (wholeLine) {
@@ -75,7 +79,7 @@ function parseTextAsKeyword(text, keyword, numberKeywords) {
 	//the thing is, keywords may have variants.  so we better check all the variants.
 	//put keyword last, check variants before it (they often have longer keyword text)
 	const variants = keyword.variants ? [...keyword.variants, keyword] : [keyword];
-	let wholeLine = Boolean(keyword.fromMultiple);
+	let wholeLine = Boolean(keyword.fromMultiple) || keyword.allowsCommas;
 	for (const variant of variants) {
 		const { parse, wholeLine: variantWholeLine } = parseTextAsKeywordOrVariant(text, variant, numberKeywords);
 		wholeLine ||= variantWholeLine;
@@ -101,6 +105,7 @@ function parseTextAsKeyword(text, keyword, numberKeywords) {
 
 function parseTextAsKeywordOrVariant(text, variant, numberKeywords) {
 	const keywordText = variant.keywordText || variant.keyword;
+	const wholeLineFromVariant = Boolean(variant.fromMultiple) || variant.allowsCommas;
 	if (Array.isArray(keywordText)) {
 		//if the keyword text is an array, meaning multiple possibilities,
 		//we'll have to try each one. I don't want to write a separate function
@@ -113,7 +118,7 @@ function parseTextAsKeywordOrVariant(text, variant, numberKeywords) {
 			);
 			if (parse !== null) return { parse, wholeLine };
 		}
-		return { parse: null, wholeLine: Boolean(variant.fromMultiple) };
+		return { parse: null, wholeLine: wholeLineFromVariant };
 	}
 	//now: does it match the keyword/variant?
 	//depends on the case.
@@ -125,19 +130,19 @@ function parseTextAsKeywordOrVariant(text, variant, numberKeywords) {
 			if (index !== -1) {
 				const argument = text.slice(0, index) || null;
 				if (argument === null && requiredness === "required") {
-					return { parse: null, wholeLine: Boolean(variant.fromMultiple) };
+					return { parse: null, wholeLine: wholeLineFromVariant };
 				}
 				const rest = text.slice(index + keywordText.length).trim();
 				const isActuallyVariant = variant.variantType === "prefix"; //as opposed to argument
 				const { parse, wholeLine } = parseRestExcludingPrefix(rest, variant, numberKeywords, isActuallyVariant);
-				if (parse === null) return { parse: null, wholeLine: wholeLine || Boolean(variant.fromMultiple)};
+				if (parse === null) return { parse: null, wholeLine: wholeLine || wholeLineFromVariant };
 				if (variant.variantType) {
 					return {
 						parse: {
 							...parse,
 							variant: argument
 						},
-						wholeLine: wholeLine || Boolean(variant.fromMultiple)
+						wholeLine: wholeLine || wholeLineFromVariant
 					};
 				} else {
 					return {
@@ -145,11 +150,11 @@ function parseTextAsKeywordOrVariant(text, variant, numberKeywords) {
 							...parse,
 							argument
 						},
-						wholeLine //fromMultiple must be false here!
+						wholeLine: wholeLine || wholeLineFromVariant
 					};
 				}
 			} else {
-				return { parse: null, wholeLine: Boolean(variant.fromMultiple) };
+				return { parse: null, wholeLine: wholeLineFromVariant };
 			}
 		}
 		case "before": {
@@ -160,20 +165,20 @@ function parseTextAsKeywordOrVariant(text, variant, numberKeywords) {
 			if (match) {
 				const argument = match[1].trim() || null;
 				if (argument === null && requiredness === "required") {
-					return { parse: null, wholeLine: Boolean(variant.fromMultiple) };
+					return { parse: null, wholeLine: wholeLineFromVariant };
 				}
 				const rest = match[2].trim();
 				//yes I copypasted some code here
 				const isActuallyVariant = variant.variantType === "before"; //as opposed to argument
 				const { parse, wholeLine } = parseRestExcludingPrefix(rest, variant, numberKeywords, isActuallyVariant);
-				if (parse === null) return { parse: null, wholeLine: wholeLine || Boolean(variant.fromMultiple)};
+				if (parse === null) return { parse: null, wholeLine: wholeLine || wholeLineFromVariant };
 				if (variant.variantType) {
 					return {
 						parse: {
 							...parse,
 							variant: argument
 						},
-						wholeLine: wholeLine || Boolean(variant.fromMultiple)
+						wholeLine: wholeLine || wholeLineFromVariant
 					};
 				} else {
 					return {
@@ -181,7 +186,7 @@ function parseTextAsKeywordOrVariant(text, variant, numberKeywords) {
 							...parse,
 							argument
 						},
-						wholeLine
+						wholeLine: wholeLine || wholeLineFromVariant
 					};
 				}
 			} else {
@@ -190,20 +195,20 @@ function parseTextAsKeywordOrVariant(text, variant, numberKeywords) {
 						parse: {
 							keyword: variant.keyword
 						},
-						wholeLine: Boolean(variant.fromMultiple)
+						wholeLine: wholeLineFromVariant
 					};
 				} else {
-					return { parse: null, wholeLine: Boolean(variant.fromMultiple) };
+					return { parse: null, wholeLine: wholeLineFromVariant };
 				}
 			}
 		}
 		default: {
-			const match = text.match(new RegExp(`^${keywordText}\\b(.*)`, "i"))
+			const match = text.match(new RegExp(`^${keywordText}(\\b|\\s|$)(.*)`, "i"))
 			if (match) {
-				const rest = match[1].trim();
+				const rest = match[2].trim();
 				return parseRest(rest, variant, numberKeywords);
 			} else {
-				return { parse: null, wholeLine: Boolean(variant.fromMultiple) };
+				return { parse: null, wholeLine: wholeLineFromVariant };
 			}
 		}
 	}
@@ -239,6 +244,7 @@ function parseRestExcludingPrefix(rest, keyword, numberKeywords, isActuallyVaria
 }
 
 function parseRest(rest, keyword, numberKeywords) {
+	const wholeLineFromKeyword = Boolean(keyword.fromMultiple) || keyword.allowsCommas;
 	if (!keyword.variant) {
 		//if there's no variant, we can skip straight to the argument and cost
 		return parseArgumentAndCost(rest, keyword, numberKeywords);
@@ -281,7 +287,7 @@ function parseRest(rest, keyword, numberKeywords) {
 			Boolean(keyword.cost) //allow lonely X only when there's a cost
 		);
 		const { parse: recursiveParse, wholeLine: wholeLineFromRecursion } = parseArgumentAndCost(argumentText || "", keyword, numberKeywords);
-		const wholeLine = wholeLineFromSplit || wholeLineFromRecursion || Boolean(keyword.fromMultiple);
+		const wholeLine = wholeLineFromSplit || wholeLineFromRecursion || wholeLineFromKeyword;
 		if (variant === "" && keyword.variant === "required") {
 			return { parse: null, wholeLine };
 		}
@@ -307,7 +313,7 @@ function parseRest(rest, keyword, numberKeywords) {
 			numberKeywords
 		);
 		if (recursiveParse === null) {
-			return { parse: null, wholeLine: wholeLine || Boolean(keyword.fromMultiple) };
+			return { parse: null, wholeLine: wholeLine || wholeLineFromKeyword };
 		}
 		return {
 			parse: {
@@ -315,36 +321,37 @@ function parseRest(rest, keyword, numberKeywords) {
 				variant: recursiveParse.argument,
 				argument: undefined
 			},
-			wholeLine: wholeLine || Boolean(keyword.fromMultiple)
+			wholeLine: wholeLine || wholeLineFromKeyword
 		};
 	}
 }
 
 function parseArgumentAndCost(rest, keyword, numberKeywords) {
+	const wholeLineFromKeyword = Boolean(keyword.fromMultiple) || keyword.allowsCommas;
 	if (!keyword.argument) {
 		//if there's no argument, just handle cost
 		if (keyword.cost) {
 			const { cost, wholeLine } = checkCost(rest, keyword.costMultiple, false);
 			if (cost === null && (keyword.cost === "required" || rest !== "")) {
-				return { parse: null, wholeLine: false }; //don't need to worry about fromMultiple
+				return { parse: null, wholeLine: wholeLine || wholeLineFromKeyword }
 			}
 			return {
 				parse: {
 					keyword: keyword.keyword,
 					cost
 				},
-				wholeLine //can leave this as-is
+				wholeLine //can leave this as-is; no argument, just cost, and we found it, so nothing to worry about
 			};
 		} else if (rest === "") {
 			return {
 				parse: {
 					keyword: keyword.keyword
 				},
-				wholeLine: Boolean(keyword.fromMultiple)
+				wholeLine: wholeLineFromKeyword
 			};
 		} else {
 			//no keyword, no cost, but there's something left over? uh-oh
-			return { parse: null, wholeLine: Boolean(keyword.fromMultiple) };
+			return { parse: null, wholeLine: wholeLineFromKeyword };
 		}
 	} else if (keyword.reverseOrder) {
 		//reverseOrder reverses the order of argument and cost. so cost, then dash, then argument
@@ -355,10 +362,10 @@ function parseArgumentAndCost(rest, keyword, numberKeywords) {
 			(argument === null && keyword.argument === "required") ||
 			(cost === null && keyword.cost === "required")
 		) {
-			return { parse: null, wholeLine: false };
+			return { parse: null, wholeLine: wholeLine || wholeLineFromKeyword };
 		}
 		if (!isManaCost(cost)) {
-			return { parse: null, wholeLine: false };
+			return { parse: null, wholeLine: wholeLine || wholeLineFromKeyword };
 		}
 		return {
 			parse: {
@@ -366,7 +373,7 @@ function parseArgumentAndCost(rest, keyword, numberKeywords) {
 				argument,
 				cost
 			},
-			wholeLine //can leave this as-is
+			wholeLine: wholeLine || wholeLineFromKeyword
 		};
 	} else if (keyword.argumentType === "dashed") {
 		//in this case, there can *only* be a argument. nothing else.
@@ -411,7 +418,7 @@ function parseArgumentAndCost(rest, keyword, numberKeywords) {
 			} = splitOnCostStart(rest, keyword.costMultiple, true)); //allow an X restriction
 		}
 		const { argument, wholeLine: wholeLineFromArgument } = checkType(argumentText, keyword.argumentType, numberKeywords, true); //allow X since there's a cost
-		const wholeLine = wholeLineFromCost || wholeLineFromArgument;
+		const wholeLine = wholeLineFromCost || wholeLineFromArgument || wholeLineFromKeyword;
 		//check: if X is present, make sure it's in a way that makes sense
 		//(note that "X, where..." doesn't have these requirements)
 		if (argument === "X" !== Boolean((cost || "").match(/\bX\b/))) {
@@ -454,7 +461,7 @@ function parseArgumentAndCost(rest, keyword, numberKeywords) {
 				//two
 				args = [match[1], match[2]]
 			} else {
-				if (rest.length > 0 && !rest.includes(",")) {
+				if (rest.length > 0) { //may (unfortunately) contain commas! see Nevinyrral e.g.
 					//one
 					args = [rest];
 				}
@@ -480,14 +487,14 @@ function parseArgumentAndCost(rest, keyword, numberKeywords) {
 		//in this case just do a check
 		const { argument, wholeLine } = checkType(rest, keyword.argumentType, numberKeywords, false);
 		if (argument === null && (keyword.argument === "required" || rest !== "")) {
-			return { parse: null, wholeLine: wholeLine || Boolean(keyword.fromMultiple) };
+			return { parse: null, wholeLine: wholeLine || wholeLineFromKeyword };
 		}
 		return {
 			parse: {
 				keyword: keyword.keyword,
 				argument
 			},
-			wholeLine: wholeLine || Boolean(keyword.fromMultiple)
+			wholeLine: wholeLine || wholeLineFromKeyword
 		};
 	}
 }
@@ -556,7 +563,7 @@ function checkType(text, type, numberKeywords, allowLonelyX) { //NOTE: returns a
 				//...except in some cases we allow it anyway, if allowLonelyX is set...
 				return { argument: allowLonelyX ? text : null, wholeLine: true };
 			} else if (text.startsWith("—")) {
-				const argument = text.slice(1).trim();
+				const argument = text.slice(1).trim().toLowerCase();
 				if (numberKeywords.includes(argument)) {
 					return { argument, wholeLine: false };
 				} else {
@@ -626,7 +633,7 @@ function splitOnNumericStart(text, numberKeywords, allowLonelyX) {
 			//in this case, we need to check whether it's followed
 			//by a numeric keyword
 			const argument = text.slice(dashIndex).trim(); //note: INCLUDE the dash! for later processing
-			if (numberKeywords.includes(argument.slice(1))) { //better remove it here though
+			if (numberKeywords.includes(argument.slice(1).toLowerCase())) { //better remove it here though
 				return {
 					variant: text.slice(0, dashIndex).trim(),
 					argument,

--- a/custom_modules/keywordParser.js
+++ b/custom_modules/keywordParser.js
@@ -1,0 +1,663 @@
+//NOTE: officially, "protection from everything" is a variant, but I chose to leave it as argument
+
+function parseRulesTextForKeywordAbilities(rulesText, keywords) {
+	const numberKeywords = keywords.filter(keyword => keyword.actsAsNumber).map(keyword => keyword.keyword); //I'm assuming no variants do this
+	let keywordsFound = [];
+	const lines = rulesText.split(/\r?\n/);
+	lines: for (const line of lines) {
+		let keywordsFoundOnLine = [];
+		const segments = line.split(/[,;]\s*/);
+		for (const segment of segments) {
+			//we're going to check each segment to see if it's a keyword.
+			//if it's *not* a keyword, we discard the entire line, since
+			//no line ever contains both keyword and non-keyword segments.
+			const { parse, wholeLine } = parseSegment(segment, line, keywords, numberKeywords);
+			const parses = handleArrays(parse);
+			if (parse !== null) {
+				if (wholeLine) {
+					//in this case, we throw out everything else we have, keep only this
+					//parse, and then move on to the next line
+					keywordsFoundOnLine = parses;
+					break;
+				} else {
+					//normal case: found a keyword, continue to next segment
+					keywordsFoundOnLine = keywordsFoundOnLine.concat(parses);
+				}
+			} else {
+				//keyword and non-keyword abilities are never mixed on a line.
+				//if we see a non-keyword ability, this isn't a keyword line.
+				//toss it out and move onto the next one.
+				continue lines;
+			}
+		}
+		//if we made it here, append what we have!
+		keywordsFound = keywordsFound.concat(keywordsFoundOnLine);
+	}
+	return keywordsFound;
+}
+
+function handleArrays(parse) {
+	if (!parse) return null;
+	let { keyword, variant: variants, argument: args, cost: costs } = parse;
+	if (!Array.isArray(variants)) variants = [variants]; //note: right now this will never be an array, but...
+	if (!Array.isArray(args)) args = [args];
+	if (!Array.isArray(costs)) costs = [costs];
+	//(also right now only at most one will be an array, but let's be general)
+	const parses = [].concat(...variants.map(variant =>
+		[].concat(...args.map(argument =>
+			costs.map(cost => ({ keyword, variant, argument, cost }))
+		))
+	));
+	return parses;
+}
+
+function parseSegment(segment, line, keywords, numberKeywords) {
+	for (const keyword of keywords) {
+		let { parse, wholeLine } = parseTextAsKeyword(segment, keyword, numberKeywords);
+		if (wholeLine) {
+			const { parse: wholeLineParse } = parseTextAsKeyword(line, keyword, numberKeywords);
+			if (wholeLineParse !== null) {
+				parse = wholeLineParse;
+			} else {
+				//if the whole line parse didn't work, make sure to report this as
+				//a segment parse, not a whole line parse
+				wholeLine = false;
+			}
+		}
+		if (parse !== null) {
+			return { parse, wholeLine };
+		}
+	}
+	return { parse: null, wholeLine: false };
+}
+
+function parseTextAsKeyword(text, keyword, numberKeywords) {
+	//the thing is, keywords may have variants.  so we better check all the variants.
+	//put keyword last, check variants before it (they often have longer keyword text)
+	const variants = keyword.variants ? [...keyword.variants, keyword] : [keyword];
+	let wholeLine = Boolean(keyword.fromMultiple);
+	for (const variant of variants) {
+		const { parse, wholeLine: variantWholeLine } = parseTextAsKeywordOrVariant(text, variant, numberKeywords);
+		wholeLine ||= variantWholeLine;
+		if (parse !== null) {
+			if (variant.keyword !== keyword.keyword) {
+				//if it was a variant, we need to appropriately transform it before
+				//returning it.
+				return {
+					parse: {
+						...parse,
+						variant: parse.keyword,
+						keyword: keyword.keyword
+					},
+					wholeLine
+				};
+			} else {
+				return { parse, wholeLine };
+			}
+		}
+	}
+	return { parse: null, wholeLine };
+}
+
+function parseTextAsKeywordOrVariant(text, variant, numberKeywords) {
+	const keywordText = variant.keywordText || variant.keyword;
+	if (Array.isArray(keywordText)) {
+		//if the keyword text is an array, meaning multiple possibilities,
+		//we'll have to try each one. I don't want to write a separate function
+		//for that, we'll just call this one again.
+		for (const possibility of keywordText) {
+			const { parse, wholeLine } = parseTextAsKeywordOrVariant(
+				text,
+				{ ...variant, keywordText: possibility },
+				numberKeywords
+			);
+			if (parse !== null) return { parse, wholeLine };
+		}
+		return { parse: null, wholeLine: Boolean(variant.fromMultiple) };
+	}
+	//now: does it match the keyword/variant?
+	//depends on the case.
+	const type = variant.variantType || variant.argumentType;
+	const requiredness = variant.variantType ? variant.variant : variant.argument;
+	switch (type) {
+		case "prefix": {
+			const index = text.toLowerCase().indexOf(keywordText.toLowerCase());
+			if (index !== -1) {
+				const argument = text.slice(0, index) || null;
+				if (argument === null && requiredness === "required") {
+					return { parse: null, wholeLine: Boolean(variant.fromMultiple) };
+				}
+				const rest = text.slice(index + keywordText.length).trim();
+				const isActuallyVariant = variant.variantType === "prefix"; //as opposed to argument
+				const { parse, wholeLine } = parseRestExcludingPrefix(rest, variant, numberKeywords, isActuallyVariant);
+				if (parse === null) return { parse: null, wholeLine: wholeLine || Boolean(variant.fromMultiple)};
+				if (variant.variantType) {
+					return {
+						parse: {
+							...parse,
+							variant: argument
+						},
+						wholeLine: wholeLine || Boolean(variant.fromMultiple)
+					};
+				} else {
+					return {
+						parse: {
+							...parse,
+							argument
+						},
+						wholeLine //fromMultiple must be false here!
+					};
+				}
+			} else {
+				return { parse: null, wholeLine: Boolean(variant.fromMultiple) };
+			}
+		}
+		case "before": {
+			//OK I guess this one's also a little annoying
+			//note: we assume no regex-significant characters in the keyword text.
+			//don't want to have to deal with escaping.
+			const match = text.match(new RegExp(`(.*)\\b${keywordText}(.*)`, "i"));
+			if (match) {
+				const argument = match[1].trim() || null;
+				if (argument === null && requiredness === "required") {
+					return { parse: null, wholeLine: Boolean(variant.fromMultiple) };
+				}
+				const rest = match[2].trim();
+				//yes I copypasted some code here
+				const isActuallyVariant = variant.variantType === "before"; //as opposed to argument
+				const { parse, wholeLine } = parseRestExcludingPrefix(rest, variant, numberKeywords, isActuallyVariant);
+				if (parse === null) return { parse: null, wholeLine: wholeLine || Boolean(variant.fromMultiple)};
+				if (variant.variantType) {
+					return {
+						parse: {
+							...parse,
+							variant: argument
+						},
+						wholeLine: wholeLine || Boolean(variant.fromMultiple)
+					};
+				} else {
+					return {
+						parse: {
+							...parse,
+							argument
+						},
+						wholeLine
+					};
+				}
+			} else {
+				if (text.trim().toLowerCase() === keywordText.toLowerCase() && requiredness === "optional") {
+					return {
+						parse: {
+							keyword: variant.keyword
+						},
+						wholeLine: Boolean(variant.fromMultiple)
+					};
+				} else {
+					return { parse: null, wholeLine: Boolean(variant.fromMultiple) };
+				}
+			}
+		}
+		default: {
+			const match = text.match(new RegExp(`^${keywordText}\\b(.*)`, "i"))
+			if (match) {
+				const rest = match[1].trim();
+				return parseRest(rest, variant, numberKeywords);
+			} else {
+				return { parse: null, wholeLine: Boolean(variant.fromMultiple) };
+			}
+		}
+	}
+	//can't make it here, no need to do anything
+}
+
+function parseRestExcludingPrefix(rest, keyword, numberKeywords, isActuallyVariant) {
+	if (!isActuallyVariant) {
+		//usual case
+		return parseRest(
+			rest,
+			{
+				...keyword,
+				//null out the argument that we've already processed
+				argument: undefined,
+				argumentType: undefined
+			},
+			numberKeywords
+		);
+	} else {
+		//this case is currently unused
+		return parseRest(
+			rest,
+			{
+				...keyword,
+				//null out the variant that we've already processed
+				variant: undefined,
+				variantType: undefined
+			},
+			numberKeywords
+		);
+	}
+}
+
+function parseRest(rest, keyword, numberKeywords) {
+	if (!keyword.variant) {
+		//if there's no variant, we can skip straight to the argument and cost
+		return parseArgumentAndCost(rest, keyword, numberKeywords);
+	}
+	if (keyword.variantType === "dashed") {
+		//in this case, there can *only* be a variant. nothing else.
+		if (rest.startsWith("—")) {
+			const variant = rest.slice(1).trim();
+			if (variant !== "") {
+				return {
+					parse: {
+						keyword: keyword.keyword,
+						variant
+					},
+					wholeLine: true
+				};
+			} else {
+				return { parse: null, wholeLine: true };
+			}
+		} else {
+			if (rest === "" && keyword.variant === "optional") {
+				return {
+					parse: {
+						keyword: keyword.keyword
+					},
+					wholeLine: true
+				};
+			} else {
+				return { parse: null, wholeLine: true };
+			}
+		}
+	} else if (keyword.argument) {
+		//in this case, we need to start by performing a split.
+		//note that in this case, the argument (if present) *must* have a type other
+		//than normal (so, dashed or numeric). this is what makes the split possible
+		const { variant, argument: argumentText, wholeLine: wholeLineFromSplit } = splitByArgumentType(
+			rest,
+			keyword.argumentType,
+			numberKeywords,
+			Boolean(keyword.cost) //allow lonely X only when there's a cost
+		);
+		const { parse: recursiveParse, wholeLine: wholeLineFromRecursion } = parseArgumentAndCost(argumentText || "", keyword, numberKeywords);
+		const wholeLine = wholeLineFromSplit || wholeLineFromRecursion || Boolean(keyword.fromMultiple);
+		if (variant === "" && keyword.variant === "required") {
+			return { parse: null, wholeLine };
+		}
+		if (recursiveParse === null) {
+			return { parse: null, wholeLine };
+		}
+		return {
+			parse: {
+				...recursiveParse,
+				variant: variant || null,
+			},
+			wholeLine
+		};
+	} else {
+		//parse it like it's argument-cost, but modify appropriately
+		const { parse: recursiveParse, wholeLine } = parseArgumentAndCost(
+			rest,
+			{
+				...keyword,
+				argument: keyword.variant,
+				argumentType: keyword.variantType
+			},
+			numberKeywords
+		);
+		if (recursiveParse === null) {
+			return { parse: null, wholeLine: wholeLine || Boolean(keyword.fromMultiple) };
+		}
+		return {
+			parse: {
+				...recursiveParse,
+				variant: recursiveParse.argument,
+				argument: undefined
+			},
+			wholeLine: wholeLine || Boolean(keyword.fromMultiple)
+		};
+	}
+}
+
+function parseArgumentAndCost(rest, keyword, numberKeywords) {
+	if (!keyword.argument) {
+		//if there's no argument, just handle cost
+		if (keyword.cost) {
+			const { cost, wholeLine } = checkCost(rest, keyword.costMultiple, false);
+			if (cost === null && (keyword.cost === "required" || rest !== "")) {
+				return { parse: null, wholeLine: false }; //don't need to worry about fromMultiple
+			}
+			return {
+				parse: {
+					keyword: keyword.keyword,
+					cost
+				},
+				wholeLine //can leave this as-is
+			};
+		} else if (rest === "") {
+			return {
+				parse: {
+					keyword: keyword.keyword
+				},
+				wholeLine: Boolean(keyword.fromMultiple)
+			};
+		} else {
+			//no keyword, no cost, but there's something left over? uh-oh
+			return { parse: null, wholeLine: Boolean(keyword.fromMultiple) };
+		}
+	} else if (keyword.reverseOrder) {
+		//reverseOrder reverses the order of argument and cost. so cost, then dash, then argument
+		const { variant: cost, argument, wholeLine } = splitOnDash(rest);
+		//check that cost looks like a cost -- we won't use checkCost here as it's not the right mechanism;
+		//this needs to be a mana cost
+		if (
+			(argument === null && keyword.argument === "required") ||
+			(cost === null && keyword.cost === "required")
+		) {
+			return { parse: null, wholeLine: false };
+		}
+		if (!isManaCost(cost)) {
+			return { parse: null, wholeLine: false };
+		}
+		return {
+			parse: {
+				keyword: keyword.keyword,
+				argument,
+				cost
+			},
+			wholeLine //can leave this as-is
+		};
+	} else if (keyword.argumentType === "dashed") {
+		//in this case, there can *only* be a argument. nothing else.
+		if (rest.startsWith("—")) {
+			const argument = rest.slice(1).trim();
+			if (argument !== "") {
+				return {
+					parse: {
+						keyword: keyword.keyword,
+						argument
+					},
+					wholeLine: true
+				};
+			} else {
+				return { parse: null, wholeLine: true };
+			}
+		} else {
+			if (rest === "" && keyword.argument === "optional") {
+				return {
+					parse: {
+						keyword: keyword.keyword
+					},
+					wholeLine: true
+				};
+			} else {
+				return { parse: null, wholeLine: true };
+			}
+		}
+	} else if (keyword.cost) {
+		//also start with a split
+		//note: if argument is numeric, the cost should use a dash
+		let argumentText, cost, wholeLineFromCost;
+		if (keyword.argumentType === "numeric") {
+			//yeah we gotta jigger things around some
+			({ variant: argumentText, argument: cost, wholeLine: wholeLineFromCost } = splitOnDash(rest));
+		} else {
+			({
+				argument: argumentText,
+				cost,
+				costText,
+				wholeLine: wholeLineFromCost
+			} = splitOnCostStart(rest, keyword.costMultiple, true)); //allow an X restriction
+		}
+		const { argument, wholeLine: wholeLineFromArgument } = checkType(argumentText, keyword.argumentType, numberKeywords, true); //allow X since there's a cost
+		const wholeLine = wholeLineFromCost || wholeLineFromArgument;
+		//check: if X is present, make sure it's in a way that makes sense
+		//(note that "X, where..." doesn't have these requirements)
+		if (argument === "X" !== Boolean((cost || "").match(/\bX\b/))) {
+			return { parse: null, wholeLine };
+		}
+		//I wanted to have an additional check here, that if "X can't be 0" appears, that
+		//X also appears elsewhere in the cost, but hell with it.  it's too much of a pain
+		if (
+			((keyword.argument === "required" || argumentText !== "") && argument === null) ||
+			((keyword.cost === "required" || costText !== "") && cost === null)
+		) {
+			return { parse: null, wholeLine };
+		}
+		return {
+			parse: {
+				keyword: keyword.keyword,
+				argument,
+				cost
+			},
+			wholeLine
+		};
+	} else if (keyword.fromMultiple) {
+		//oh boy!
+		const keywordText = keyword.keywordText || keyword.keyword; //remember: we assume this ends in keyword.fromMultiple
+		const base = keywordText.slice(0,-keyword.fromMultiple.length).trim();
+		const preposition = keyword.fromMultiple;
+		let args = [];
+		//note that at this point, rest contains everything *after* the preposition
+		let match;
+		match = rest.match(new RegExp(
+			`^([^,]+),\\s+${preposition}\\s+([^,]+),\\s+and\\s+${preposition}\\s+([^,]+)$`,
+			"i"
+		));
+		if (match) {
+			//three
+			args = [match[1], match[2], match[3]]
+		} else {
+			match = rest.match(new RegExp(`^([^,]+)\\s+and\\s+${preposition}\\s+([^,]+)$`, "i"));
+			if (match) {
+				//two
+				args = [match[1], match[2]]
+			} else {
+				if (rest.length > 0 && !rest.includes(",")) {
+					//one
+					args = [rest];
+				}
+			}
+		}
+		if (args.length === 0) {
+			return { parse: null, wholeLine: true };
+		}
+		//we've extracted the raw possibilities, but now we need to perform "each color" expansion
+		const index = args.indexOf("each color");
+		if (index !== -1) {
+			const colors = ["white", "blue", "black", "red", "green"];
+			args.splice(index, 1, ...colors);
+		}
+		return {
+			parse: {
+				keyword: keyword.keyword,
+				argument: args
+			},
+			wholeLine: true
+		};
+	} else {
+		//in this case just do a check
+		const { argument, wholeLine } = checkType(rest, keyword.argumentType, numberKeywords, false);
+		if (argument === null && (keyword.argument === "required" || rest !== "")) {
+			return { parse: null, wholeLine: wholeLine || Boolean(keyword.fromMultiple) };
+		}
+		return {
+			parse: {
+				keyword: keyword.keyword,
+				argument
+			},
+			wholeLine: wholeLine || Boolean(keyword.fromMultiple)
+		};
+	}
+}
+
+function checkCost(text, allowMultiple, allowXRestriction) {
+	//does this look basically like a cost?
+	if (allowMultiple) {
+		const costs = parseMultipleCosts(text);
+		if (costs) {
+			return { cost: costs, wholeLine: false };
+		}
+	}
+	if (isManaCost(text, allowXRestriction)) return { cost: text, wholeLine: false };
+	if (text.startsWith("—")) {
+		const cost = text.slice(1).trim() || null;
+		return { cost, wholeLine: true };
+	}
+	return { cost: null, wholeLine: false };
+}
+
+function isManaCost(text, allowXRestriction) {
+	//does this look basically like a mana cost? but allow or'ing some
+	if (!allowXRestriction) {
+		return Boolean(text.match(/^(\{[a-zA-Z0-9\/]+\})+(\s+or\s+(\{[a-zA-Z0-9\/]+\})+)?$/));
+	} else {
+		return Boolean(text.match(/^(\{[a-zA-Z0-9\/]+\})+(\s+or\s+(\{[a-zA-Z0-9\/]+\})+)?(\.\s+X\s+.*)?$/));
+	}
+}
+
+function isDirectManaCost(text) {
+	//does this look basically like a mana cost?
+	return Boolean(text.match(/^(\{[a-zA-Z0-9\/]+\})+$/));
+}
+
+function parseMultipleCosts(text) {
+	const match = text.match(/^((\{[a-zA-Z0-9\/]+\})+)\s+and\/or\s+((\{[a-zA-Z0-9\/]+\})+)$/);
+	if (match) {
+		return [match[1], match[3]];
+	} else {
+		return null;
+	}
+}
+
+function checkType(text, type, numberKeywords, allowLonelyX) { //NOTE: returns argument even though may be variant
+	switch(type) {
+		//we assume it's not "prefix" or "before" as those are handled above
+		case undefined:
+			if (text.startsWith("—")) {
+				//this shouldn't happen
+				return { argument: null, wholeLine: false };
+			} else if (text === "") {
+				return { argument: null, wholeLine: false };
+			} else {
+				return { argument: text, wholeLine: false };
+			}
+		case "numeric":
+			if (text.match(/^[0-9]+$/)) {
+				//note: I'm assuming we don't have to deal with commas in numbers like
+				//on The Millennium Calendar
+				return { argument: text, wholeLine: false };
+			} else if (text.startsWith("X, where X is")) {
+				return { argument: text, wholeLine: true };
+			} else if (text === "X") {
+				//if we've got an X, uh-oh, we may need the whole line!
+				//(where's the comma? not in this segment!)
+				//...except in some cases we allow it anyway, if allowLonelyX is set...
+				return { argument: allowLonelyX ? text : null, wholeLine: true };
+			} else if (text.startsWith("—")) {
+				const argument = text.slice(1).trim();
+				if (numberKeywords.includes(argument)) {
+					return { argument, wholeLine: false };
+				} else {
+					return { argument: null, wholeLine: false };
+				}
+			} else {
+				return { argument: null, wholeLine: false };
+			}
+		case "dashed":
+			if (text.startsWith("—")) {
+				const argument = text.slice(1).trim() || null;
+				return { argument, wholeLine: true };
+			} else {
+				return { argument: null, wholeLine: false };
+			}
+	}
+}
+
+function splitOnCostStart(text, allowMultiple, allowXRestriction) {
+	let braceIndex = text.indexOf("{");
+	if (braceIndex === -1) braceIndex = Infinity;
+	let dashIndex = text.indexOf("—");
+	if (dashIndex === -1) dashIndex = Infinity;
+	const index = Math.min(braceIndex, dashIndex);
+	if (index !== Infinity) {
+		const costText = text.slice(index);
+		const argument = text.slice(0, index).trim(); //note: depending on context this could be a variant
+		const { cost, wholeLine } = checkCost(costText, allowMultiple, allowXRestriction);
+		return { argument, cost, costText, wholeLine };
+	}
+	//otherwise, both are infinity
+	return { argument: text, cost: null, costText: "", wholeLine: false };
+}
+
+function splitByArgumentType(text, type, numberKeywords, allowLonelyX) {
+	switch(type) {
+		//note that case undefined should never occur!!
+		case "numeric":
+			return splitOnNumericStart(text, numberKeywords, allowLonelyX);
+		case "dashed":
+			return splitOnDash(text);
+	}
+}
+
+function splitOnNumericStart(text, numberKeywords, allowLonelyX) {
+	const numMatch = text.match(/\d/);
+	const numIndex = numMatch ? numMatch.index : Infinity;
+	let xIndex = text.indexOf("X, where X is");
+	if (xIndex === -1) xIndex = Infinity;
+	let bareXIndex = text.indexOf("X—");
+	if (bareXIndex === -1) bareXIndex = text.endsWith("X") ? text.length - 1 : Infinity;
+	let dashIndex = text.indexOf("—");
+	if (dashIndex === -1) dashIndex = Infinity;
+	const nonDashIndex = allowLonelyX
+		? Math.min(numIndex, xIndex, bareXIndex)
+		: Math.min(numIndex, xIndex);
+	const index = Math.min(dashIndex, nonDashIndex);
+	if (index === Infinity) {
+		if (bareXIndex !== Infinity) {
+			//note that this can only happen if allowLonelyX is false
+			return { variant: text, argument: null, wholeLine: true };
+		} else {
+			return { variant: text, argument: null, wholeLine: false };
+		}
+	} else {
+		if (dashIndex < nonDashIndex) {
+			//in this case, we need to check whether it's followed
+			//by a numeric keyword
+			const argument = text.slice(dashIndex).trim(); //note: INCLUDE the dash! for later processing
+			if (numberKeywords.includes(argument.slice(1))) { //better remove it here though
+				return {
+					variant: text.slice(0, dashIndex).trim(),
+					argument,
+					wholeLine: false
+				};
+			}
+		}
+		//normal cases follow
+		if (nonDashIndex === Infinity) {
+			return { variant: text, argument: null, wholeLine: false };
+		}
+		return {
+			variant: text.slice(0, nonDashIndex).trim(),
+			argument: text.slice(nonDashIndex),
+			wholeLine: index === bareXIndex
+		};
+	}
+}
+
+function splitOnDash(text) {
+	const index = text.indexOf("—");
+	if (index === -1) {
+		return { variant: text, argument: null, wholeLine: false };
+	}
+	return {
+		variant: text.slice(0, index).trim(),
+		argument: text.slice(index+1).trim() || null, //don't include the dash
+		wholeLine: true
+	};
+}
+
+module.exports = {
+	parse: parseRulesTextForKeywordAbilities
+}

--- a/custom_modules/keywordParser.js
+++ b/custom_modules/keywordParser.js
@@ -283,8 +283,7 @@ function parseRest(rest, keyword, numberKeywords) {
 		const { variant, argument: argumentText, wholeLine: wholeLineFromSplit } = splitByArgumentType(
 			rest,
 			keyword.argumentType,
-			numberKeywords,
-			Boolean(keyword.cost) //allow lonely X only when there's a cost
+			numberKeywords
 		);
 		const { parse: recursiveParse, wholeLine: wholeLineFromRecursion } = parseArgumentAndCost(argumentText || "", keyword, numberKeywords);
 		const wholeLine = wholeLineFromSplit || wholeLineFromRecursion || wholeLineFromKeyword;
@@ -331,7 +330,7 @@ function parseArgumentAndCost(rest, keyword, numberKeywords) {
 	if (!keyword.argument) {
 		//if there's no argument, just handle cost
 		if (keyword.cost) {
-			const { cost, wholeLine } = checkCost(rest, keyword.costMultiple, false);
+			const { cost, wholeLine } = checkCost(rest, keyword.costMultiple);
 			if (cost === null && (keyword.cost === "required" || rest !== "")) {
 				return { parse: null, wholeLine: wholeLine || wholeLineFromKeyword }
 			}
@@ -356,14 +355,14 @@ function parseArgumentAndCost(rest, keyword, numberKeywords) {
 	} else if (keyword.reverseOrder) {
 		//reverseOrder reverses the order of argument and cost. so cost, then dash, then argument
 		const { variant: cost, argument, wholeLine } = splitOnDash(rest);
-		//check that cost looks like a cost -- we won't use checkCost here as it's not the right mechanism;
-		//this needs to be a mana cost
 		if (
 			(argument === null && keyword.argument === "required") ||
 			(cost === null && keyword.cost === "required")
 		) {
 			return { parse: null, wholeLine: wholeLine || wholeLineFromKeyword };
 		}
+		//check that cost looks like a cost -- we won't use checkCost here as it's not the right mechanism;
+		//this needs to be a mana cost (and no qualifiers!)
 		if (!isManaCost(cost)) {
 			return { parse: null, wholeLine: wholeLine || wholeLineFromKeyword };
 		}
@@ -409,23 +408,32 @@ function parseArgumentAndCost(rest, keyword, numberKeywords) {
 		if (keyword.argumentType === "numeric") {
 			//yeah we gotta jigger things around some
 			({ variant: argumentText, argument: cost, wholeLine: wholeLineFromCost } = splitOnDash(rest));
+			costText = cost || ""; //the only way we can fail to get a cost here is if it's empty (sorry)
 		} else {
 			({
 				argument: argumentText,
 				cost,
 				costText,
 				wholeLine: wholeLineFromCost
-			} = splitOnCostStart(rest, keyword.costMultiple, true)); //allow an X restriction
+			} = splitOnCostStart(rest, keyword.costMultiple));
 		}
-		const { argument, wholeLine: wholeLineFromArgument } = checkType(argumentText, keyword.argumentType, numberKeywords, true); //allow X since there's a cost
+		const {
+			argument,
+			cost: qualifier,
+			wholeLine: wholeLineFromArgument
+		} = checkType(argumentText, keyword.argumentType, numberKeywords);
 		const wholeLine = wholeLineFromCost || wholeLineFromArgument || wholeLineFromKeyword;
-		//check: if X is present, make sure it's in a way that makes sense
+		//check: if the argument is X, make sure X also appears in the cost or qualifier
 		//(note that "X, where..." doesn't have these requirements)
-		if (argument === "X" !== Boolean((cost || "").match(/\bX\b/))) {
+		if (
+			argument === "X" &&
+			!((cost || "").match(/\bX\b/)) &&
+			!((qualifier || "").match(/\bX\b/)))
+		{
 			return { parse: null, wholeLine };
 		}
-		//I wanted to have an additional check here, that if "X can't be 0" appears, that
-		//X also appears elsewhere in the cost, but hell with it.  it's too much of a pain
+		//Note: the following check for cost does *not* treat a qualifier as a cost!
+		//It wants an actual cost!
 		if (
 			((keyword.argument === "required" || argumentText !== "") && argument === null) ||
 			((keyword.cost === "required" || costText !== "") && cost === null)
@@ -436,7 +444,7 @@ function parseArgumentAndCost(rest, keyword, numberKeywords) {
 			parse: {
 				keyword: keyword.keyword,
 				argument,
-				cost
+				cost: cost || qualifier
 			},
 			wholeLine
 		};
@@ -485,21 +493,22 @@ function parseArgumentAndCost(rest, keyword, numberKeywords) {
 		};
 	} else {
 		//in this case just do a check
-		const { argument, wholeLine } = checkType(rest, keyword.argumentType, numberKeywords, false);
+		const { argument, cost, wholeLine } = checkType(rest, keyword.argumentType, numberKeywords);
 		if (argument === null && (keyword.argument === "required" || rest !== "")) {
 			return { parse: null, wholeLine: wholeLine || wholeLineFromKeyword };
 		}
 		return {
 			parse: {
 				keyword: keyword.keyword,
-				argument
+				argument,
+				cost //really a qualiier
 			},
 			wholeLine: wholeLine || wholeLineFromKeyword
 		};
 	}
 }
 
-function checkCost(text, allowMultiple, allowXRestriction) {
+function checkCost(text, allowMultiple) {
 	//does this look basically like a cost?
 	if (allowMultiple) {
 		const costs = parseMultipleCosts(text);
@@ -507,7 +516,12 @@ function checkCost(text, allowMultiple, allowXRestriction) {
 			return { cost: costs, wholeLine: false };
 		}
 	}
-	if (isManaCost(text, allowXRestriction)) return { cost: text, wholeLine: false };
+	//the following RE differs from the one in isManaCost in that it allows a qualifier after
+	const match = text.match(/^(\{[a-zA-Z0-9\/]+\})+(\s+or\s+(\{[a-zA-Z0-9\/]+\})+)?(\.\s+(.*))?$/);
+	if (match) {
+		//if the qualifier part matched, we need to check the whole line
+		return { cost: text, wholeLine: Boolean(match[4]) };
+	}
 	if (text.startsWith("—")) {
 		const cost = text.slice(1).trim() || null;
 		return { cost, wholeLine: true };
@@ -515,18 +529,9 @@ function checkCost(text, allowMultiple, allowXRestriction) {
 	return { cost: null, wholeLine: false };
 }
 
-function isManaCost(text, allowXRestriction) {
-	//does this look basically like a mana cost? but allow or'ing some
-	if (!allowXRestriction) {
-		return Boolean(text.match(/^(\{[a-zA-Z0-9\/]+\})+(\s+or\s+(\{[a-zA-Z0-9\/]+\})+)?$/));
-	} else {
-		return Boolean(text.match(/^(\{[a-zA-Z0-9\/]+\})+(\s+or\s+(\{[a-zA-Z0-9\/]+\})+)?(\.\s+X\s+.*)?$/));
-	}
-}
-
-function isDirectManaCost(text) {
-	//does this look basically like a mana cost?
-	return Boolean(text.match(/^(\{[a-zA-Z0-9\/]+\})+$/));
+function isManaCost(text) {
+	//does this look basically like a mana cost? but allow or'ing two of them
+	return Boolean(text.match(/^(\{[a-zA-Z0-9\/]+\})+(\s+or\s+(\{[a-zA-Z0-9\/]+\})+)?$/));
 }
 
 function parseMultipleCosts(text) {
@@ -538,7 +543,7 @@ function parseMultipleCosts(text) {
 	}
 }
 
-function checkType(text, type, numberKeywords, allowLonelyX) { //NOTE: returns argument even though may be variant
+function checkType(text, type, numberKeywords) { //NOTE: returns argument even though may be variant
 	switch(type) {
 		//we assume it's not "prefix" or "before" as those are handled above
 		case undefined:
@@ -561,7 +566,7 @@ function checkType(text, type, numberKeywords, allowLonelyX) { //NOTE: returns a
 				//if we've got an X, uh-oh, we may need the whole line!
 				//(where's the comma? not in this segment!)
 				//...except in some cases we allow it anyway, if allowLonelyX is set...
-				return { argument: allowLonelyX ? text : null, wholeLine: true };
+				return { argument: text, wholeLine: true };
 			} else if (text.startsWith("—")) {
 				const argument = text.slice(1).trim().toLowerCase();
 				if (numberKeywords.includes(argument)) {
@@ -569,8 +574,23 @@ function checkType(text, type, numberKeywords, allowLonelyX) { //NOTE: returns a
 				} else {
 					return { argument: null, wholeLine: false };
 				}
+			} else if (text.startsWith("X. ")) {
+				return {
+					argument: "X",
+					cost: text.slice(2).trim(), //!! we count qualifiers as costs
+					wholeLine: true
+				};
 			} else {
-				return { argument: null, wholeLine: false };
+				const match = text.match(/^([0-9]+)\.\s+(.*)$/);
+				if (match) {
+					return {
+						argument: match[1],
+						cost: match[2], //again!
+						wholeLine: true
+					};
+				} else {
+					return { argument: null, wholeLine: false };
+				}
 			}
 		case "dashed":
 			if (text.startsWith("—")) {
@@ -582,7 +602,7 @@ function checkType(text, type, numberKeywords, allowLonelyX) { //NOTE: returns a
 	}
 }
 
-function splitOnCostStart(text, allowMultiple, allowXRestriction) {
+function splitOnCostStart(text, allowMultiple) {
 	let braceIndex = text.indexOf("{");
 	if (braceIndex === -1) braceIndex = Infinity;
 	let dashIndex = text.indexOf("—");
@@ -591,43 +611,40 @@ function splitOnCostStart(text, allowMultiple, allowXRestriction) {
 	if (index !== Infinity) {
 		const costText = text.slice(index);
 		const argument = text.slice(0, index).trim(); //note: depending on context this could be a variant
-		const { cost, wholeLine } = checkCost(costText, allowMultiple, allowXRestriction);
+		const { cost, wholeLine } = checkCost(costText, allowMultiple);
 		return { argument, cost, costText, wholeLine };
 	}
 	//otherwise, both are infinity
 	return { argument: text, cost: null, costText: "", wholeLine: false };
 }
 
-function splitByArgumentType(text, type, numberKeywords, allowLonelyX) {
+function splitByArgumentType(text, type, numberKeywords) {
 	switch(type) {
 		//note that case undefined should never occur!!
 		case "numeric":
-			return splitOnNumericStart(text, numberKeywords, allowLonelyX);
+			return splitOnNumericStart(text, numberKeywords);
 		case "dashed":
 			return splitOnDash(text);
 	}
 }
 
-function splitOnNumericStart(text, numberKeywords, allowLonelyX) {
+function splitOnNumericStart(text, numberKeywords) {
 	const numMatch = text.match(/\d/);
 	const numIndex = numMatch ? numMatch.index : Infinity;
 	let xIndex = text.indexOf("X, where X is");
 	if (xIndex === -1) xIndex = Infinity;
-	let bareXIndex = text.indexOf("X—");
+	let xDashIndex = text.indexOf("X—");
+	if (xDashIndex === -1) xIndex = Infinity;
+	let xDotIndex = text.indexOf("X.");
+	if (xDotIndex === -1) xIndex = Infinity;
+	let bareXIndex = Math.min(xDashIndex, xDotIndex); //an X followed by a dash or period, instead of comma, is considered "bare"
 	if (bareXIndex === -1) bareXIndex = text.endsWith("X") ? text.length - 1 : Infinity;
 	let dashIndex = text.indexOf("—");
 	if (dashIndex === -1) dashIndex = Infinity;
-	const nonDashIndex = allowLonelyX
-		? Math.min(numIndex, xIndex, bareXIndex)
-		: Math.min(numIndex, xIndex);
+	const nonDashIndex = Math.min(numIndex, xIndex, bareXIndex);
 	const index = Math.min(dashIndex, nonDashIndex);
 	if (index === Infinity) {
-		if (bareXIndex !== Infinity) {
-			//note that this can only happen if allowLonelyX is false
-			return { variant: text, argument: null, wholeLine: true };
-		} else {
-			return { variant: text, argument: null, wholeLine: false };
-		}
+		return { variant: text, argument: null, wholeLine: false };
 	} else {
 		if (dashIndex < nonDashIndex) {
 			//in this case, we need to check whether it's followed

--- a/custom_modules/updateDataFiles.js
+++ b/custom_modules/updateDataFiles.js
@@ -11,6 +11,8 @@ const rootDir = path.join(__dirname, "..");
 const rgUtils = require(path.join(rootDir, "custom_modules/rgUtils.js"));
 rgUtils.setUpErrorHandling();
 
+const keywordParser = require("./keywordParser");
+
 //This script will crash when creating/dispersing the files if it doesn't have enough memory, so we just crash it here to not waste time downloading all the files first.
 if (v8.getHeapStatistics().heap_size_limit < 10**9) {
 	throw new Error("Not enough memory allocated.");
@@ -447,6 +449,7 @@ const updateAllCards = function(verbose = false) {
 		if ((allCards[i].layout === "split" || allCards[i].layout === "aftermath") && allCards[i].side === "a") {
 			let aName = allCards[i].name;
 			// bName is the element of names that aName isn't
+			if (allCards[i].names) {
 			let bName = allCards[i].names[0];
 			if(bName === aName){
 				bName = allCards[i].names[1];
@@ -469,6 +472,7 @@ const updateAllCards = function(verbose = false) {
 			currentCard.layout = "split (full)";
 			delete currentCard.side;
 			combinedCards[currentCard.name] = currentCard;
+			}
 		}
 	}
 	Object.assign(allCards, combinedCards);
@@ -658,6 +662,13 @@ const updateAllCards = function(verbose = false) {
 				delete allCards[i][allProps[j]];
 			}
 		}
+	}
+
+	const keywordDetails = JSON5.parse(fs.readFileSync("custom_modules/keywordDetails.json", "utf8"));
+
+	for (let i in allCards) {
+		//add keyword details with the new keyword parser
+		allCards[i].keywordDetails = keywordParser.parse(allCards[i].rulesText, keywordDetails);
 	}
 
 	//Remove MTGJSON's hallucinatory keywords.


### PR DESCRIPTION
**Note**: This PR should probably not be merged until #279 (or something like it) is merged, for reasons I'll explain below.

Anyway, this PR is intended to address #18 -- at least partly.  I'm going ahead and PRing this so it can get some review, but it might not be entirely ready yet; this PR adds a new keyword parser, but doesn't yet fully hook it up to make it usable.  It adds a new field to cards, but doesn't yet add any way to actually use or search that field.  Thought should see what you think first.

The parser is, well, a bit complicated, but it's meant to be thorough.  I've tested it on the real card file and I think it does quite well (I did find a few bugs this way but I've fixed them).  Note that it relies on a JSON file full of information about Magic's keyword abilities, so **this would require activate maintenance if merged** -- the JSON file would need to be updated whenever a new keyword ability is added, but also, the parser itself might need to be occasionally updated when a new keyword or card comes out that breaks the assumptions built into it (of which there are many).  If you're not willing to commit to such maintenance then maybe you don't want this!

Also, **note that this keyword parser only looks for keyword abilities, not keyword actions**.  Keyword actions vary too much in how they appear on cards; it'd be hard to do something like this for them.  Moreover, it only finds keyword abilities that the card simply *has* -- not keyword abilities it conditionally grants to itself or anything like that.  This even applies to cases like [Minthara, Merciless Soul](https://scryfall.com/card/clb/286/minthara-merciless-soul) -- since it *grants itself* ward {X}, rather than simply *having* ward {X}, the parser won't find it, even though it grants itself the ability unconditionally.  (The parser could perhaps be modified to handle cases like Minthara -- of which there are only a few, I believe -- but I'm not sure, that might be difficult.)

I mentioned above that this shouldn't be merged until #279 (or something like it) is.  That's because the parser relies on reminder text, flavor words, etc., being stripped out beforehand; it can fail if they aren't.  So, we'd need to have our list of flavor words up to date, with something like #279.  If you just merge this, then what you'll find is that it'll fail to detect the equip abilities on many of the equipment from Final Fantasy, because those are using flavor words that we don't presently know about.

Anyway, given some card text, the parser will return an array of keywords that it has.  Each keyword in the array is an object with fields `keyword`, `variant`, `argument`, and `cost`; this is based on the structure you suggested on Discord.  I think this structure is sometimes and awkward fit, and we might want to consider changing it (like perhaps adding a `qualifier` field, or allowing two arguments), but this is what I've gone with for now.

Let's talk about just how that breaks down.  The `keyword` field is the overall keyword, without any information about what variant it might be.  So if your card has "choose a Background", the keyword field will be "partner", since choose a Background is a partner variant.

The `variant` field contains the specific variant.  Note that keywords can have *fixed* variants -- a finite list of variants -- or they can allow *open-ended* variants... or they can have both, like partner!  I mean, according to the rules, the various "partner—whatever" variants come from a fixed list, but I figured it made more sense to treat that as open-ended; whereas "partner with", "Doctor's companion", and "choose a Background" are fixed variants.  (I also treated the different things you can gift as if it were open-ended, even though it's not, because, well, it didn't seem worth the effort, but that can of course be changed if you think it should be.)

The `argument` field contains a (non-cost) argument.  This may be numeric or it may not be.  In some cases, like with forecast, the argument is an entire ability.  I'll note that I chose to treat exhaust this way, even though the rules define exhaust as having a cost and effect (different from how they handle forecast, for whatever reason).  Whatever, this was simpler.  Note that some keyword abilities, like devour, arguably have two arguments; in this case, **I treated the first argument as the variant, and the second as the argument**.

Finally, the `cost` field contains any associated cost.  **It also contains any other additional qualifiers that go in a separate sentence**, and this field can appear for that reason even if there's no cost in the normal sense (although this only comes up on two cards).  Often these are cost reducers, so it makes sense to group them with the cost.  Other times though they're saying that this ability can only be activated once each turn -- does that really belong with the cost?  Well, maybe.  The really awkward case is [Ob Nixilis, the Adversary](https://scryfall.com/card/snc/206/ob-nixilis-the-adversary); on his casualty ability, that second sentence, "The copy isn’t legendary and has starting loyalty X.", ends up in the cost field.  Perhaps there should be a separate `qualifier` field to handle things like this?  That said, this is currently the only card where it's that bad.

As an illustration, if a card has Swampcycling {2}, then the `keyword` would be "cycling", the `variant` would be "typecycling", the `argument` would be "Swamp", and the `cost` would be "{2}".  If a card has equip {2}, then the keyword would be "equip", the "cost" would be {2}, and the other two fields would be undefined or null.  If instead it were "equip legendary creature {2}", then the `argument` field would now be populated with "legendary creature".  And if instead it were "equip planeswalker {2}", then the `argument` field would not be populated, but the `variant` field would be "equip planeswalker", since equip planeswalker is considered a variant.

As mentioned what's returned by the parser is an array of such objects; if a card has multiple instances of a keyword, it'll appear multiple times, with the appropriate additional info each time.  Note that yes we do return multiple abilities if there's "kicker X and/or Y", or "protection from X and from Y" or "hexproof from X and from Y", or the 3-case variant, or "protection from each color", etc.  The rules define that these are shorthand for multiple abilities, and we treat it as such.

(A particularly annoying card here is [Nevinyrral, Urborg Tyrant](https://scryfall.com/card/cmr/287/nevinyrral-urborg-tyrant).  You'd *think* they'd have templated it as "hexproof from artifacts, from creatures, and from enchantments", making it shorthand for 3 separate abilities.  But they didn't!  So instead it's all one big ability, and the parser treats it that way.  That caused a bug at first...)

Let me say a bit about the JSON format I devised for the keyword info.  Each keyword has a `keyword` field, which is the name of the keyword.  This is the only required field; all other fields are optional.  The `keywordText` field can be included for when the text of the keyword differs from its name; this can also be an array if there's multiple possibilities here.  Then there's the `variants` field, which is an array; it's where you specify any fixed variants, each of which gets a specification like this of its own (so each has its own `keyword` field that is the name of the variant, etc).  Properties of the keyword are *not* inherited by the variant -- if you want them to carry over you'll have to specify them a second time.  Also, a variant appearing here should *not* have a `variants` field of its own!

Then there's `variant` (different from `variants`), which is how you specify that there can be open-ended variants; this can be set to either `"required"` or `"optional"` (just leave it out if there shouldn't be any open-ended variants).  The `argument` and `cost` fields work similarly, for arguments and costs.  But there are also the fields `variantType` and `argumentType`.  If left out, this means that the type of the variant or argument is pretty much freeform; but you can set either of these to `"dashed"` to indicate that the variant or argument should follow a dash (I thought of breaking this case down further but decided against it), or to `"numeric"` to indicate that the variant or argument should be a number in some sense.  Doesn't necessarily need to be a numeral; other numbers are possible, such as "X, where X is the number of creature cards in your graveyard" -- that's a number!  Also, Sunburst can be a number!  Although of course this is only currently used on the card [Arcbound Wanderer](https://scryfall.com/card/mma/200/arcbound-wanderer).  Note that the parser does **not** report this card as having sunburst; it has modular with an argument of "Sunburst".  But if you think it should be reported as having sunburst, well, that could be changed!  (Although it would mess with the existing structure, so it would take some doing.)  Anyway if they ever print a card with "Devour—Sunburst", we'll be ready. :P

Finally, we've got the weirdo options, which only appear on a few abilities.  The `reverseOrder` flag, currently used only on prototype, indicates that the cost comes before the argument.  The `allowsCommas` flag indicates that the ability allows commas in its argument/variant/whatever, in situations where that might otherwise not be expected.  (Like, commas are always allowed after a dash, or in a second separate sentence.  But this indicates that commas are allowed even without that.) The `actsAsNumber` flag, currently used only on sunburst, indicates that this keyword can act as a number.  The `costMultiple` flag, currently used only on kicker, turns on the special handling of the "kicker X and/or Y" templating.  And then finally we've got the `fromMultiple` field, which is used on protection and on the "hexproof from" variant of hexproof.  This field -- which is not a flag, its value should be set to the preposition used, of course currently this is always `"from"` -- turns on the special handling of the "from X and from Y" and "from X, from Y, and from Z" and "from each color" templates.

Like I said, I've tried to make this fairly general, but I ultimately did end up encoding into it a number of assumptions for simplicity, and it would need modification if those assumptions are ever broken.  I tried to come up with a list of such assumptions; I do not promise this is exhaustive, but examples are:

* fixed variants may not have variants of their own (whether fixed or free)
* keywords and keywordText may not contain any regexp-meaningful characters
* reverseOrder is only allowed if both argument and cost are present
* There may be at most one of: a cost; a dashed argument; a dashed variant
* At most one of the variant or argument may be before/prefix
* If the variant is dashed, there may be no argument or cost
* If the argument is dashed, there may be no cost
* If there is both a variant and an argument, the argument must have a type OTHER than normal, before, or prefix
* The numeric type is not permitted for variants
* If fromMultiple is used, the keyword text must end in it (with whitespace before)
* fromMultiple is not allowed if there's a cost (and so not allowed if reverseOrder)
* fromMultiple or allowsCommas is only allowed if the argument is normal type
* A keyword with a numeric argument, if it has a special X form like bloodthirst, won't ever have the usual numeric X (@_@)
* There won't be a cost with {X} with X then defined afterward
* costMultiple won't be used with argument type numeric
* Numeric arguments won't contain commas (even though a number with commas happens on [The Millennium Calendar](https://scryfall.com/card/lci/257/the-millennium-calendar)!)

So, yeah, like I said -- this might need some active maintenance if we merge it.

Whew, all this, and I haven't even gotten to describing the implementation details.  Well -- I think I'll just mostly skip going over that.

The one thing I do want to discuss there is the `wholeLine` system.  Basically, the parser first breaks the text apart into lines (note that we consider semicolons to essentially be line separations), then into segments (separated by commas).  For each line, it attempts to parse each segment.  If *any* fails, *none* of the segment parses from that line are used, because keyword and non-keyword abilities will never be mixed on a line like that.  But, observing certain things will trigger the parser to try parsing the *entire* line as a single keyword ability.  If this succeeds, it overrides the segment parses, which are all thrown out in favor of the whole-line parse.  If the whole line doesn't parse as a keyword ability, though, then the segment parses are used (well, or not used, depending on whether they were all good or not).

OK, I think that's all I've got to say about this!  Hope the code quality isn't too bad, but I think this works pretty dang well, I spent a fair bit of time going over weird cases and making sure it could handle them. :)